### PR TITLE
Fix white flash loading dark-theme pages

### DIFF
--- a/css/fermyon.css
+++ b/css/fermyon.css
@@ -637,146 +637,146 @@ footer .footer-nav p {
   }
 }
 
-body.dark-theme {
+html.dark-theme > body {
   color: #fff;
   background: #0d203f;
 }
 
-body.dark-theme h1, body.dark-theme h2, body.dark-theme h3, body.dark-theme h4, body.dark-theme h5, body.dark-theme p, body.dark-theme li {
+html.dark-theme > body h1, html.dark-theme > body h2, html.dark-theme > body h3, html.dark-theme > body h4, html.dark-theme > body h5, html.dark-theme > body p, html.dark-theme > body li {
   color: #fff;
 }
 
-body.dark-theme #topbar.navbar {
+html.dark-theme > body #topbar.navbar {
   background: #0d203f;
   border-color: #0a455a;
 }
 
-body.dark-theme #topbar.navbar .logo svg, body.dark-theme #topbar.navbar .logo path {
+html.dark-theme > body #topbar.navbar .logo svg, html.dark-theme > body #topbar.navbar .logo path {
   fill: #fff !important;
 }
 
-body.dark-theme #topbar.navbar .logo-project a {
+html.dark-theme > body #topbar.navbar .logo-project a {
   color: #34e8bd;
 }
 
-body.dark-theme #topbar.navbar .logo-project a .tag {
+html.dark-theme > body #topbar.navbar .logo-project a .tag {
   background-color: #213762;
   color: #bea7e5 !important;
 }
 
-body.dark-theme #topbar.navbar .navbar-burger {
+html.dark-theme > body #topbar.navbar .navbar-burger {
   color: #bea7e5;
   height: 5.75rem;
 }
 
-body.dark-theme #topbar.navbar .navbar-menu a {
+html.dark-theme > body #topbar.navbar .navbar-menu a {
   color: #34e8bd;
 }
 
-body.dark-theme #topbar.navbar .navbar-menu .button {
+html.dark-theme > body #topbar.navbar .navbar-menu .button {
   border: 3px solid #34e8bd;
 }
 
-body.dark-theme #topbar.navbar .navbar-menu .button:hover {
+html.dark-theme > body #topbar.navbar .navbar-menu .button:hover {
   color: #0d203f;
   background: #34e8bd !important;
 }
 
-body.dark-theme #topbar.navbar .dark-mode svg {
+html.dark-theme > body #topbar.navbar .dark-mode svg {
   fill: #34e8bd;
   transition: all .3s ease-in-out;
   transform: rotate(180deg);
 }
 
-body.dark-theme .menu-wrap {
+html.dark-theme > body .menu-wrap {
   background: #0d203f;
 }
 
-body.dark-theme aside.menu:hover {
+html.dark-theme > body aside.menu:hover {
   border-right: 2px solid #321a59;
 }
 
-body.dark-theme aside.menu a {
+html.dark-theme > body aside.menu a {
   color: #fff;
 }
 
-body.dark-theme aside.menu a:hover {
+html.dark-theme > body aside.menu a:hover {
   color: #34e8bd;
   background-color: #213762;
 }
 
-body.dark-theme aside.menu a.button svg, body.dark-theme aside.menu a.button path {
+html.dark-theme > body aside.menu a.button svg, html.dark-theme > body aside.menu a.button path {
   fill: #fff !important;
 }
 
-body.dark-theme pre {
+html.dark-theme > body pre {
   background: linear-gradient(0, #173564 15%, #233e68 100%);
 }
 
-body.dark-theme .card {
+html.dark-theme > body .card {
   background: linear-gradient(0, #112b54, #0d203f 100%);
   color: #fff;
   outline: 1px solid #fff3;
   box-shadow: 0 .5em 1em -.125em #0a0a0a80, 0 0 0 1px #0a0a0a85;
 }
 
-body.dark-theme .card figure.image {
+html.dark-theme > body .card figure.image {
   border-bottom: 1px solid #fff5;
 }
 
-body.dark-theme .card p {
+html.dark-theme > body .card p {
   color: #fff;
 }
 
-body.dark-theme .content .box {
+html.dark-theme > body .content .box {
   color: #fff;
   background-color: #213762;
 }
 
-body.dark-theme .content h1 code, body.dark-theme .content h2 code, body.dark-theme .content h3 code, body.dark-theme .content h4 code, body.dark-theme .content h5 code, body.dark-theme .content p code, body.dark-theme .content li code, body.dark-theme .content th code, body.dark-theme .content td code, body.dark-theme .content dd code {
+html.dark-theme > body .content h1 code, html.dark-theme > body .content h2 code, html.dark-theme > body .content h3 code, html.dark-theme > body .content h4 code, html.dark-theme > body .content h5 code, html.dark-theme > body .content p code, html.dark-theme > body .content li code, html.dark-theme > body .content th code, html.dark-theme > body .content td code, html.dark-theme > body .content dd code {
   color: #ece5ee;
   background-color: #213762;
 }
 
-body.dark-theme .content section table {
+html.dark-theme > body .content section table {
   background-color: #213762;
 }
 
-body.dark-theme .content blockquote {
+html.dark-theme > body .content blockquote {
   background-color: #0000;
 }
 
-body.dark-theme .content blockquote p {
+html.dark-theme > body .content blockquote p {
   color: #fff;
   background-color: #1b2c4f;
   border-color: #243c6c;
 }
 
-body.dark-theme .content blockquote > blockquote p, body.dark-theme .content aside p {
+html.dark-theme > body .content blockquote > blockquote p, html.dark-theme > body .content aside p {
   color: #fff;
   background-color: #243c6c;
   border-color: #2b477f;
 }
 
-body.dark-theme .content a:hover {
+html.dark-theme > body .content a:hover {
   background: #1b2c4f !important;
 }
 
-body.dark-theme footer {
+html.dark-theme > body footer {
   color: #fff;
   background: #0d203f;
   border-color: #0a455a;
 }
 
-body.dark-theme footer h4 {
+html.dark-theme > body footer h4 {
   color: #fff;
 }
 
-body.dark-theme footer .footer-nav {
+html.dark-theme > body footer .footer-nav {
   border-color: #06101f;
 }
 
-body.dark-theme footer p, body.dark-theme footer li, body.dark-theme footer a {
+html.dark-theme > body footer p, html.dark-theme > body footer li, html.dark-theme > body footer a {
   color: #34e8bd;
 }
 
@@ -1156,20 +1156,20 @@ body {
   text-decoration: underline;
 }
 
-body.dark-theme {
+html.dark-theme > body {
   color: #fff;
   background: #0d203f;
 }
 
-body.dark-theme h1, body.dark-theme h2, body.dark-theme h3, body.dark-theme h4, body.dark-theme p, body.dark-theme li {
+html.dark-theme > body h1, html.dark-theme > body h2, html.dark-theme > body h3, html.dark-theme > body h4, html.dark-theme > body p, html.dark-theme > body li {
   color: #fff;
 }
 
-body.dark-theme .content a, body.dark-theme article a {
+html.dark-theme > body .content a, html.dark-theme > body article a {
   color: #34e8bd;
 }
 
-body.dark-theme .content strong, body.dark-theme article strong {
+html.dark-theme > body .content strong, html.dark-theme > body article strong {
   color: #ece5ee;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,6 +66,51 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="//cdn.rawgit.com/zenorocha/clipboard.js/master/dist/clipboard.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/headroom/0.12.0/headroom.min.js" integrity="sha512-9UsrKTYzS9smDm2E58MLs0ACtOki+UC4bBq4iK5wi7lJycwqcaiHxr1bdEsIVoK0l5STEzLUdYyDdFQ5OEjczw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+
+        // The default theme is the system theme, unless the user has
+        // explicitly overridden it.
+        var savedTheme = localStorage.getItem("theme") || systemTheme;
+        setTheme(savedTheme);
+
+        document.addEventListener("DOMContentLoaded", () => {
+            const btn = document.querySelector(".dark-mode");
+            btn.addEventListener("click", () => {
+                if (savedTheme === "dark") {
+                    setTheme("light");
+                } else if (savedTheme === "light") {
+                    setTheme("dark");
+                }
+            });
+        })
+
+        // Change the website theme when the system theme changes.
+        window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", (event) => {
+                if (event.matches) {
+                    setTheme("dark");
+                } else {
+                    setTheme("light");
+                }
+            });
+
+        // Change the website theme when a different tab changed it.
+        window.onstorage = () => {
+            // When local storage changes, update the theme.
+            setTheme(localStorage.getItem("theme"));
+        };
+
+
+        function setTheme(mode) {
+            localStorage.setItem("theme", mode);
+            savedTheme = mode;
+            document.documentElement.classList.toggle('dark-theme', mode === "dark");
+        }
+    </script>
 </head>
 <body>
     <header class="navbar is-transparent is-wide" id="topbar">
@@ -1357,53 +1402,6 @@ Sen, Europa, Avenir, system, -apple-system, ".SFNSText-Regular", "San Francisco"
         </div>
     </footer>
 
-    <script>
-        const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
-            ? "dark"
-            : "light";
-
-            // The default theme is the system theme, unless the user has
-            // explicitly overriden it.
-            var savedTheme = localStorage.getItem("theme") || systemTheme;
-            setTheme(savedTheme);
-
-            const btn = document.querySelector(".dark-mode");
-            btn.addEventListener("click", () => {
-            if(savedTheme === "dark") {
-                setTheme("light");
-            } else if(savedTheme === "light") {
-                setTheme("dark");
-            }
-            });
-
-            // Change the website theme when the system theme changes.
-            window
-            .matchMedia("(prefers-color-scheme: dark)")
-            .addEventListener("change", (event) => {
-                if (event.matches) {
-                setTheme("dark");
-                } else {
-                setTheme("light");
-                }
-            });
-
-            // Change the website theme when a different tab changed it.
-            window.onstorage = () => {
-            // When local storage changes, update the theme.
-            setTheme(localStorage.getItem("theme"));
-            };
-
-
-            function setTheme(mode) {
-            localStorage.setItem("theme", mode);
-            savedTheme = mode;
-            if (mode === "dark") {
-                document.body.classList.add('dark-theme');
-            } else if (mode === "light") {
-                document.body.classList.remove('dark-theme');
-            }
-        }
-    </script>
     <script>
         var header = new Headroom(document.querySelector("#topbar"), {
             tolerance: 5,

--- a/docs/layout-docs.html
+++ b/docs/layout-docs.html
@@ -35,7 +35,51 @@
     />
     <link href="https://fonts.googleapis.com/css2?family=Sen:wght@400;700&amp;display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../scss/fermyon.scss" />
+    <script>
+        const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
 
+        // The default theme is the system theme, unless the user has
+        // explicitly overridden it.
+        var savedTheme = localStorage.getItem("theme") || systemTheme;
+        setTheme(savedTheme);
+
+        document.addEventListener("DOMContentLoaded", () => {
+            const btn = document.querySelector(".dark-mode");
+            btn.addEventListener("click", () => {
+                if (savedTheme === "dark") {
+                    setTheme("light");
+                } else if (savedTheme === "light") {
+                    setTheme("dark");
+                }
+            });
+        })
+
+        // Change the website theme when the system theme changes.
+        window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", (event) => {
+                if (event.matches) {
+                    setTheme("dark");
+                } else {
+                    setTheme("light");
+                }
+            });
+
+        // Change the website theme when a different tab changed it.
+        window.onstorage = () => {
+            // When local storage changes, update the theme.
+            setTheme(localStorage.getItem("theme"));
+        };
+
+
+        function setTheme(mode) {
+            localStorage.setItem("theme", mode);
+            savedTheme = mode;
+            document.documentElement.classList.toggle('dark-theme', mode === "dark");
+        }
+    </script>
 </head>
 <body class="documentation">
     <header class="navbar is-transparent is-wide" id="topbar">
@@ -200,34 +244,6 @@ volumes = { "content/" = "content/" , "templates/" = "templates/", "scripts/" = 
             </div>
         </div>
     </footer>
-
-    <script>
-        const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-        if (prefersDarkScheme.matches) {
-        document.body.classList.add('dark-theme');
-        } else {
-        document.body.classList.remove('dark-theme');
-        }
-
-        // toggle light and dark mode
-        const btn = document.querySelector(".dark-mode");
-        const currentTheme = localStorage.getItem("theme");
-
-        if (currentTheme == "dark") {
-        document.body.classList.add("dark-theme");
-        }
-
-        btn.addEventListener("click", function() {
-        document.body.classList.toggle("dark-theme");
-        
-        let theme = "light";
-        if (document.body.classList.contains("dark-theme")) {
-            theme = "dark";
-        }
-        // save theme to localstorage
-        localStorage.setItem("theme", theme);
-        });
-    </script>
 
 </body>
 </html>

--- a/docs/layout-widedocs.html
+++ b/docs/layout-widedocs.html
@@ -36,6 +36,51 @@
     <link href="https://fonts.googleapis.com/css2?family=Sen:wght@400;700&amp;display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../scss/fermyon.scss" />
 
+    <script>
+        const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+
+        // The default theme is the system theme, unless the user has
+        // explicitly overridden it.
+        var savedTheme = localStorage.getItem("theme") || systemTheme;
+        setTheme(savedTheme);
+
+        document.addEventListener("DOMContentLoaded", () => {
+            const btn = document.querySelector(".dark-mode");
+            btn.addEventListener("click", () => {
+                if (savedTheme === "dark") {
+                    setTheme("light");
+                } else if (savedTheme === "light") {
+                    setTheme("dark");
+                }
+            });
+        })
+
+        // Change the website theme when the system theme changes.
+        window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", (event) => {
+                if (event.matches) {
+                    setTheme("dark");
+                } else {
+                    setTheme("light");
+                }
+            });
+
+        // Change the website theme when a different tab changed it.
+        window.onstorage = () => {
+            // When local storage changes, update the theme.
+            setTheme(localStorage.getItem("theme"));
+        };
+
+
+        function setTheme(mode) {
+            localStorage.setItem("theme", mode);
+            savedTheme = mode;
+            document.documentElement.classList.toggle('dark-theme', mode === "dark");
+        }
+    </script>
 </head>
 <body class="documentation">
     <header class="navbar is-transparent is-wide" id="topbar">
@@ -200,34 +245,6 @@ volumes = { "content/" = "content/" , "templates/" = "templates/", "scripts/" = 
             </div>
         </div>
     </footer>
-
-    <script>
-        const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-        if (prefersDarkScheme.matches) {
-        document.body.classList.add('dark-theme');
-        } else {
-        document.body.classList.remove('dark-theme');
-        }
-
-        // toggle light and dark mode
-        const btn = document.querySelector(".dark-mode");
-        const currentTheme = localStorage.getItem("theme");
-
-        if (currentTheme == "dark") {
-        document.body.classList.add("dark-theme");
-        }
-
-        btn.addEventListener("click", function() {
-        document.body.classList.toggle("dark-theme");
-        
-        let theme = "light";
-        if (document.body.classList.contains("dark-theme")) {
-            theme = "dark";
-        }
-        // save theme to localstorage
-        localStorage.setItem("theme", theme);
-        });
-    </script>
 
 </body>
 </html>

--- a/scss/fermyon-base.scss
+++ b/scss/fermyon-base.scss
@@ -580,7 +580,7 @@ footer {
     }
 }
 
-body.dark-theme {
+html.dark-theme > body {
     background: $oxfordblue;
     color: white;
 

--- a/scss/fermyon-type.scss
+++ b/scss/fermyon-type.scss
@@ -355,7 +355,7 @@ body {
     pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}.hljs{color:#abb2bf;background:#282c34}.hljs-comment,.hljs-quote{color:#5c6370;font-style:italic}.hljs-doctag,.hljs-formula,.hljs-keyword{color:#c678dd}.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#e06c75}.hljs-literal{color:#56b6c2}.hljs-addition,.hljs-attribute,.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:#98c379}.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#d19a66}.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#61aeee}.hljs-built_in,.hljs-class .hljs-title,.hljs-title.class_{color:#e6c07b}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:700}.hljs-link{text-decoration:underline}
 }
 
-body.dark-theme {
+html.dark-theme > body {
     background: $oxfordblue;
     color: white;
 


### PR DESCRIPTION
Move the `dark-theme` class from `<body>` to `<html>` and move the related JS into `<head>` so it will run before first page draw.

re: https://github.com/fermyon/spin/issues/253