### PR TITLE
fix npm install copy to clipboard

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -264,8 +264,8 @@
                         for <a href="https://www.fermyon.com">Fermyon</a> related materials.
                         <br><br>
                         <code class="copy is-size-4" style="padding-right: 2.5rem; margin-left: 0rem">
-                            npm install -D @fermyon/styleguide
-                            <button class="button copy-button" data-clipboard-target="#seagreen">
+                            <span id="npminstall">npm install -D @fermyon/styleguide</span>
+                            <button class="button copy-button" data-clipboard-target="#npminstall">
                                 <img src="../image/icon-copy.svg" alt="Copy to clipboard" />
                             </button>
                         </code>


### PR DESCRIPTION
There's a bug on design.fermyon.dev, where the copy to clipboard install command copies the wrong thing (the `seagreen` color value):
 
![Screen Shot 2022-03-31 at 12 00 12 PM](https://user-images.githubusercontent.com/686194/161129745-142fba86-dc84-4150-a1fb-9629e8ab637f.png)

This fixes it so it copies the `npm install` command.

Signed-off-by: Ronan Flynn-Curran <ronan@fermyon.com>