### PR TITLE
fix the styleguide docs footer layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
     gtag('config', 'G-MTXN9SDRTY');
     </script>
 </head>
-<body>
+<body class="documentation">
     <header class="navbar is-transparent is-wide" id="topbar">
         <div class="navbar-brand">
             <a class="navbar-item" href="index.html">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fermyon/styleguide",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fermyon/styleguide",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "parcel": "^2.4.0"


### PR DESCRIPTION
Small edit that fixes the html for the footer at the bottom of the styleguide at https://design.fermyon.dev/

Signed-off-by: flynnduism <ronan@fermyon.com>