### PR TITLE
Add main field for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@fermyon/styleguide",
   "version": "0.1.6",
   "homepage": "https://github.com/fermyon/styleguide",
+  "main": "scss/fermyon.scss",
   "author": {
     "name": "Ronan Flynn-Curran",
     "email": "ronan@fermyon.com",


### PR DESCRIPTION
I'm using web pack to import styles using this style guide. Something I've noticed in other sass node modules is that setting the "main" field in package.json will allow you to import using the absolute package name. I tested this locally and with this change and some typical web pack config I can import styles like this:

```sass
@import '@fermyon/styleguide';
```

Signed-off-by: Justin Pflueger <justin.pflueger@fermyon.com>